### PR TITLE
Update 2、《深入理解ES6》笔记——字符串和正则表达式.md

### DIFF
--- a/doc/2、《深入理解ES6》笔记——字符串和正则表达式.md
+++ b/doc/2、《深入理解ES6》笔记——字符串和正则表达式.md
@@ -16,7 +16,7 @@
 **codePointAt()：**
 该方法支持UTF-16，接受编码单元的位置而非字符串位置作为参数，返回与字符串中给定位置对应的码位，即一个整数值。
 
-**String.fromCodePoiont()：**作用与codePointAt相反，检索字符串中某个字符的码位，也可以根据指定的码位生成一个字符。
+**String.fromCodePoint()：**作用与codePointAt相反，检索字符串中某个字符的码位，也可以根据指定的码位生成一个字符。
 
 **normalize()**：提供Unicode的标准形式，接受一个可选的字符串参数，指明应用某种Unicode标准形式。
 


### PR DESCRIPTION
方法名fromCodePoiont书写有误，更正为fromCodePoint